### PR TITLE
added the todayBtnTxt back in IMyOptions

### DIFF
--- a/projects/angular-mydatepicker/src/lib/interfaces/my-options.interface.ts
+++ b/projects/angular-mydatepicker/src/lib/interfaces/my-options.interface.ts
@@ -52,6 +52,7 @@ export interface IMyOptions {
   stylesData?: IMyStyles;
   ariaLabelPrevMonth?: string;
   ariaLabelNextMonth?: string;
+  todayBtnTxt?:string;
 }
 
 export interface IAngularMyDpOptions extends IMyOptions { }


### PR DESCRIPTION
`this.myDatePickerOptions.todayBtnTxt = 'today';`  is breaking due to not defined in the type.
but I can use this temporarily:  `this.myDatePickerOptions['todayBtnTxt'] = 'today'; `

it is better to add the `todayBtnTxt` back to the type. 