### PR TITLE
fix strictNullType check error of possibly undefined object

### DIFF
--- a/projects/angular-mydatepicker/src/lib/components/calendar/calendar.component.html
+++ b/projects/angular-mydatepicker/src/lib/components/calendar/calendar.component.html
@@ -1,5 +1,5 @@
 <span #styleEl></span>
-<div class="ng-mydp {{opts.stylesData.selector}}">
+<div class="ng-mydp {{opts.stylesData?.selector || ''}}">
   <div class="myDpSelector" #selectorEl 
     [libAngularMyDatePickerCalendar]="{inline: opts.inline, selectorWidth: opts.selectorWidth, selectorHeight: opts.selectorHeight, selectorPos: selectorPos}" 
     [ngClass]="{'myDpSelectorArrow': opts.showSelectorArrow, 'myDpSelectorArrowLeft': opts.showSelectorArrow && !opts.alignSelectorRight, 


### PR DESCRIPTION
Fixes #31

TsConfix strictNullType checks make and error due to typecheck of `opts.stylesData` which is defined as nullable. In this case we make sure we will have the styles data, but need to assert it for the TS check